### PR TITLE
Update setup.py and README; clarify parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@ Testing D3 in React hooks in Streamlit ! Feel free to grab the inspiration :).
 ## Install
 
 ```shell script
-pip install -i https://test.pypi.org/simple/ --no-deps streamlit-d3-demo
+pip install -i https://test.pypi.org/simple/ streamlit-d3-demo
 ```
 
-## Run
+## Example Usage
 
-```shell script
-streamlit run app.py
+```python
+import random
+import streamlit as st
+from streamlit_d3_demo import d3
+
+def generate_random_data(x_r, y_r):
+    return list(zip(range(x_r), [random.randint(0, y_r) for _ in range(x_r)]))
+
+d3(generate_random_data(20, 500), circle_radius=15, circle_color="#6495ed")
 ```
 
 ## Development 

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,7 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.6",
+    install_requires=[
+        "streamlit >= 0.63",
+    ],
 )

--- a/streamlit_d3_demo/__init__.py
+++ b/streamlit_d3_demo/__init__.py
@@ -14,23 +14,38 @@ else:
 
 
 def d3(
-    d: Dict,
-    c_radius: int = 15,
-    c_color: str = "#6495ed",
+    data: Dict,
+    circle_radius: int = 15,
+    circle_color: str = "#6495ed",
     height: int = 400,
     width: int = 600,
     margin: Dict = None,
     key=None,
 ):
+    """Display data using the D3 library.
+
+    TODO: add docstrings for parameters and return value
+     (Also, it looks like the "data" param does not actually need to be a dict?
+     In the example, it's being passed a list.)
+
+    :param data:
+    :param circle_radius:
+    :param circle_color:
+    :param height:
+    :param width:
+    :param margin:
+    :param key:
+    :return:
+    """
     if margin is None:
         margin = {"top": 20, "bottom": 30, "left": 40, "right": 30}
 
     component_value = _component_func(
-        data=d,
+        data=data,
         svgHeight=height,
         svgWidth=width,
-        circleRadius=c_radius,
-        circleColor=c_color,
+        circleRadius=circle_radius,
+        circleColor=circle_color,
         margin=margin,
         key=key,
         default=None,


### PR DESCRIPTION
In addition to updating setup.py and the README, I also tweaked the parameter names for the `d3()` function call, to make them clearer.

Could you add a docstring for the d3 function as well, explaining the parameters (and its return value, if it has one)? What shape does the `data` param need to have? (The type annotation claims Dict, but the example passes it a list.) Can it handle any arbitrary D3 chart data?